### PR TITLE
Use new `static-lang-word-lists` API to filter word lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,8 +802,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "static-lang-word-lists"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5722e7b37a53bbc281b636696c3ef2c070f04259a4d313cf616c3715dadb6261"
+source = "git+https://github.com/googlefonts/fontheight?branch=slwl-word-list-editing-creation#03572edec09b0d945a1ad2d4d778fb6d9ac9afa2"
 dependencies = [
  "brotli",
  "brotli-decompressor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,8 +801,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "static-lang-word-lists"
-version = "0.4.1"
-source = "git+https://github.com/googlefonts/fontheight?branch=slwl-word-list-editing-creation#03572edec09b0d945a1ad2d4d778fb6d9ac9afa2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1665ec7209dffcfa6778d4513ff18decc04e89a70b465541a31a2499d5786d7"
 dependencies = [
  "brotli",
  "brotli-decompressor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ members = [
 
 [workspace.dependencies]
 fontheight = "=0.1.8"
+
+# FIXME: remove this after SLWL's update has been released
+[patch.crates-io]
+static-lang-word-lists = { git = "https://github.com/googlefonts/fontheight", branch = "slwl-word-list-editing-creation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,3 @@ members = [
 
 [workspace.dependencies]
 fontheight = "=0.1.8"
-
-# FIXME: remove this after SLWL's update has been released
-[patch.crates-io]
-static-lang-word-lists = { git = "https://github.com/googlefonts/fontheight", branch = "slwl-word-list-editing-creation" }

--- a/autobase-cli/src/main.rs
+++ b/autobase-cli/src/main.rs
@@ -121,21 +121,18 @@ fn generate_base_for_font(
                 .script()
                 .map(|x| supported.contains(x))
                 .unwrap_or(false)
-        });
-    // We want to filter out any words which are in the exclusions. But:
-    // - We can't clone or modify a wordlist
-    // - We can create a wordlist from an iterator but we then lose the metadata
-    // - We can't create new metadata objects or change the metadata on an existing wordlist
-    // - We can't add a filter function into par_check after par_iter because the function can't go across threads
-    // - We can't add a filter function into par_check before par_iter because we need Wordlist.par_iter to produce a ParWordListIter
-    // So there's not much we can do except get a large number of exemplars and hope for the best.
+        })
+        .map(|word_list| {
+            // Note: this will be quite slow if the list of exclusions is large
+            word_list.filter(|word| config.exclusions.iter().any(|exclusion| exclusion == word))
+        })
+        .collect::<Vec<_>>();
     let reports = wordlists
+        .iter()
         // Cartesian product relevant word lists with instances
         .flat_map(|word_list| instances.iter().zip(iter::repeat(word_list)))
         .par_bridge()
-        .map(|(reporter, word_list)| {
-            reporter.par_check(word_list, Some(args.words_per_list), 10000)
-        })
+        .map(|(reporter, word_list)| reporter.par_check(word_list, Some(args.words_per_list), 1))
         .collect::<Result<Vec<_>, _>>()?;
     let mut reports_by_script: BTreeMap<String, Vec<Report>> = BTreeMap::new();
     for report in reports.into_iter() {

--- a/autobase/src/base_script.rs
+++ b/autobase/src/base_script.rs
@@ -23,33 +23,13 @@ impl MinMax {
         let (mut highest, mut highest_word) = if r.exemplars.is_empty() {
             (None, "<none>".to_string())
         } else {
-            let h = r
-                .exemplars
-                .highest()
-                .iter()
-                .find(|w| {
-                    !config
-                        .exclusions
-                        .iter()
-                        .any(|excluded_pattern| w.word.contains(excluded_pattern))
-                })
-                .unwrap();
+            let h = r.exemplars.highest().first().unwrap();
             (Some(h.extremes.highest() as i16), h.word.to_string())
         };
         let (mut lowest, mut lowest_word) = if r.exemplars.is_empty() {
             (None, "<none>".to_string())
         } else {
-            let l = r
-                .exemplars
-                .lowest()
-                .iter()
-                .find(|w| {
-                    !config
-                        .exclusions
-                        .iter()
-                        .any(|excluded_pattern| w.word.contains(excluded_pattern))
-                })
-                .unwrap();
+            let l = r.exemplars.lowest().first().unwrap();
             (Some(l.extremes.lowest() as i16), l.word.to_string())
         };
         if let Some(ov) = override_ {


### PR DESCRIPTION
Again, sorry this didn't exist when you came to make your initial implementation!

Keeping this PR as draft until the downstream changes are released (see the Cargo.toml patch to have this build/work currently)

fontheight PR: https://github.com/googlefonts/fontheight/pull/98